### PR TITLE
Add minimize or app spread click action

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -76,12 +76,12 @@
                           <item translatable="yes">Cycle through windows</item>
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
-                          <item translatable="yes">Minimize or show previews</item>
-                          <item translatable="yes">Focus or show previews</item>
-                          <item translatable="yes">Focus or app spread</item>
-                          <item translatable="yes">Focus, minimize or show previews</item>
-                          <item translatable="yes">Focus, minimize or app spread</item>
-                          <item translatable="yes">Quit</item>
+                            <item translatable="yes">Minimize or show previews</item>
+                            <item translatable="yes">Minimize or app spread</item>
+                            <item translatable="yes">Focus or show previews</item>
+                            <item translatable="yes">Focus or app spread</item>
+                            <item translatable="yes">Focus, minimize or show previews</item>
+                            <item translatable="yes">Focus, minimize or app spread</item>
                         </items>
                         <layout>
                           <property name="column">1</property>
@@ -148,12 +148,12 @@
                           <item translatable="yes">Cycle through windows</item>
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
-                          <item translatable="yes">Minimize or show previews</item>
-                          <item translatable="yes">Focus or show previews</item>
-                          <item translatable="yes">Focus or app spread</item>
-                          <item translatable="yes">Focus, minimize or show previews</item>
-                          <item translatable="yes">Focus, minimize or app spread</item>
-                          <item translatable="yes">Quit</item>
+                            <item translatable="yes">Minimize or show previews</item>
+                            <item translatable="yes">Minimize or app spread</item>
+                            <item translatable="yes">Focus or show previews</item>
+                            <item translatable="yes">Focus or app spread</item>
+                            <item translatable="yes">Focus, minimize or show previews</item>
+                            <item translatable="yes">Focus, minimize or app spread</item>
                         </items>
                         <layout>
                           <property name="column">1</property>
@@ -220,12 +220,12 @@
                           <item translatable="yes">Cycle through windows</item>
                           <item translatable="yes">Minimize or overview</item>
                           <item translatable="yes">Show window previews</item>
-                          <item translatable="yes">Minimize or show previews</item>
-                          <item translatable="yes">Focus or show previews</item>
-                          <item translatable="yes">Focus or app spread</item>
-                          <item translatable="yes">Focus, minimize or show previews</item>
-                          <item translatable="yes">Focus, minimize or app spread</item>
-                          <item translatable="yes">Quit</item>
+                            <item translatable="yes">Minimize or show previews</item>
+                            <item translatable="yes">Minimize or app spread</item>
+                            <item translatable="yes">Focus or show previews</item>
+                            <item translatable="yes">Focus or app spread</item>
+                            <item translatable="yes">Focus, minimize or show previews</item>
+                            <item translatable="yes">Focus, minimize or app spread</item>
                         </items>
                         <layout>
                           <property name="column">1</property>
@@ -1687,11 +1687,12 @@
                                       <item translatable="yes">Cycle through windows</item>
                                       <item translatable="yes">Minimize or overview</item>
                                       <item translatable="yes">Show window previews</item>
-                                      <item translatable="yes">Minimize or show previews</item>
-                                      <item translatable="yes">Focus or show previews</item>
-                                      <item translatable="yes">Focus or app spread</item>
-                                      <item translatable="yes">Focus, minimize or show previews</item>
-                                      <item translatable="yes">Focus, minimize or app spread</item>
+                                        <item translatable="yes">Minimize or show previews</item>
+                                        <item translatable="yes">Minimize or app spread</item>
+                                        <item translatable="yes">Focus or show previews</item>
+                                        <item translatable="yes">Focus or app spread</item>
+                                        <item translatable="yes">Focus, minimize or show previews</item>
+                                        <item translatable="yes">Focus, minimize or app spread</item>
                                     </items>
                                   </object>
                                 </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -59,11 +59,12 @@ const clickAction = Object.freeze({
     MINIMIZE_OR_OVERVIEW: 4,
     PREVIEWS: 5,
     MINIMIZE_OR_PREVIEWS: 6,
-    FOCUS_OR_PREVIEWS: 7,
-    FOCUS_OR_APP_SPREAD: 8,
-    FOCUS_MINIMIZE_OR_PREVIEWS: 9,
-    FOCUS_MINIMIZE_OR_APP_SPREAD: 10,
-    QUIT: 11,
+    MINIMIZE_OR_APP_SPREAD: 7,
+    FOCUS_OR_PREVIEWS: 8,
+    FOCUS_OR_APP_SPREAD: 9,
+    FOCUS_MINIMIZE_OR_PREVIEWS: 10,
+    FOCUS_MINIMIZE_OR_APP_SPREAD: 11,
+    QUIT: 12,
 });
 
 const scrollAction = Object.freeze({
@@ -517,6 +518,10 @@ const DockAbstractAppIcon = GObject.registerClass({
         }
 
         switch (buttonAction) {
+        case clickAction.MINIMIZE_OR_APP_SPREAD:
+            if (!Docking.DockManager.getDefault().appSpread.supported)
+                buttonAction = clickAction.MINIMIZE_OR_PREVIEWS;
+            break;
         case clickAction.FOCUS_OR_APP_SPREAD:
             if (!Docking.DockManager.getDefault().appSpread.supported)
                 buttonAction = clickAction.FOCUS_OR_PREVIEWS;
@@ -668,6 +673,15 @@ const DockAbstractAppIcon = GObject.registerClass({
                     }
                 } else {
                     this.app.activate();
+                }
+                break;
+
+            case clickAction.MINIMIZE_OR_APP_SPREAD:
+                if (this.focused && !modifiers && button === 1) {
+                    this._minimizeWindow();
+                } else {
+                    shouldHideOverview = false;
+                    Docking.DockManager.getDefault().appSpread.toggle(this.app);
                 }
                 break;
 

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -8,11 +8,12 @@
     <value value='4' nick='minimize-or-overview'/>
     <value value='5' nick='previews'/>
     <value value='6' nick='minimize-or-previews'/>
-    <value value='7' nick='focus-or-previews'/>
-    <value value='8' nick='focus-or-appspread'/>
-    <value value='9' nick='focus-minimize-or-previews'/>
-    <value value='10' nick='focus-minimize-or-appspread'/>
-    <value value='11' nick='quit'/>
+    <value value='7' nick='minimize-or-appspread'/>
+    <value value='8' nick='focus-or-previews'/>
+    <value value='9' nick='focus-or-appspread'/>
+    <value value='10' nick='focus-minimize-or-previews'/>
+    <value value='11' nick='focus-minimize-or-appspread'/>
+    <value value='12' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
## Summary
- add `minimize-or-appspread` enum to schema
- implement minimize/app-spread behavior and fallback handling
- expose new option in preferences UI
- streamline minimize-or-app-spread logic to minimize on focused click or toggle app spread otherwise
- place the option after "Minimize or show previews" and hide the "Quit" choice in the UI

## Testing
- `glib-compile-schemas ./schemas/`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688f76c113ec8327902c8d2e1e53c921